### PR TITLE
Fix DataCloneError in custom `fetch()` function

### DIFF
--- a/Twitch-Server-Info.user.js
+++ b/Twitch-Server-Info.user.js
@@ -771,7 +771,7 @@ if (window.TWITCH_SERVER_INFO === undefined) {
                     const originalFetch = self.fetch;
                     self.fetch = async function(input, init){
                         // Sending messages out of the worker
-                        postMessage({"id":0,"type":"tsi","arg":input,"fixed":{"FIXED":FIXED,"FIXER_count":FIXER_count}});
+                        postMessage({"id":0,"type":"tsi","arg":(input instanceof Request ? input.url : input.toString()),"fixed":{"FIXED":FIXED,"FIXER_count":FIXER_count}});
 
                         // Server Fixer (Auto Reconnector)
                         if(FIXER


### PR DESCRIPTION
Hello,

I've noticed a bug in your custom `fetch()` function:
If the `input` parameter is of type `Request`, the first `postMessage()` call will throw an error `DataCloneError` because the `Request` object is not serializable.
Twitch doesn't use `Request` objects with `fetch()` (yet), but some extensions like mine (TTV LOL PRO) or Kaspersky Web Protection override the `fetch()` function too and use `Request` objects as the ECMAScript standard allows it. This in turn makes this script throw an error and prevents the page from loading.

The fix I found it to check if the `input` parameter is an instance of `Request`. If yes, use the `url` property. If not, use `input.toString()` (the `toString()` call is to take into account `URL` objects that can also be passed as input)

I've confirmed this fix works successfully with one user who has experienced issues.

Thanks and have a good day